### PR TITLE
config - add `compute` @ `2022-08-01`

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -5,6 +5,11 @@ resource_manager "automanage" "2022-05-04" {
   readme_file_path = "../../swagger/specification/automanage/resource-manager/readme.md"
 }
 
+resource_manager "compute" "2022-08-01" {
+  swagger_tag = "package-2022-08-01"
+  readme_file_path = "../../swagger/specification/compute/resource-manager/readme.md"
+}
+
 resource_manager "synapse" "2021-06-01" {
   swagger_tag = "package-2021-06"
   readme_file_path = "../../swagger/specification/synapse/resource-manager/readme.md"


### PR DESCRIPTION
This is to prepare for Community Image Gallery, introduced in `compute 2022-01-03` ([Swagger](https://github.com/Azure/azure-rest-api-specs/blob/fdd4e5c9b9225698c7f26c75c4b26be5c57e60f8/specification/compute/resource-manager/Microsoft.Compute/GalleryRP/stable/2022-01-03/gallery.json#L1808)).
Pandora SDK generating is pending https://github.com/hashicorp/pandora/pull/1673, and there are a few [breaking changes in sql](https://github.com/Azure/azure-sdk-for-go/blob/v67.0.0/services/preview/sql/mgmt/v5.0/sql/CHANGELOG.md#removed-struct-fields) when I try upgrading the Track 1 sdk from v66.0 to v67.0, thus adding the new sdk version here so we don't need to care about breaking changes in other services.