### PR TITLE
autowrapper: outputting the service name as the namespace

### DIFF
--- a/.github/workflows/automation-release.yaml
+++ b/.github/workflows/automation-release.yaml
@@ -2,6 +2,8 @@ name: Release the SDK
 on:
   pull_request:
     types: ['closed']
+    paths:
+      - 'sdk/**'
 
 concurrency:
   group: 'release-${{ github.head_ref }}'

--- a/.github/workflows/pull-request-unit-tests.yaml
+++ b/.github/workflows/pull-request-unit-tests.yaml
@@ -1,0 +1,37 @@
+---
+name: Validate the Track1 SDKs can be regenerated
+on:
+  pull_request:
+    types: ['opened', 'synchronized']
+
+jobs:
+  test-regenerate-the-track1-sdks:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.18.5'
+
+      - uses: actions/setup-dotnet@v3
+        with:
+          # The Track1 AutoRest Generator requires .net core 2.x
+          dotnet-version: 2.2.x
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Generate Track1 SDKs
+        run: |
+          cd ./tools/autowrapper
+          make tools
+          make run
+        env:
+          NODE_OPTIONS: "--max-old-space-size=4096"

--- a/.github/workflows/pull-request-unit-tests.yaml
+++ b/.github/workflows/pull-request-unit-tests.yaml
@@ -2,7 +2,7 @@
 name: Validate the Track1 SDKs can be regenerated
 on:
   pull_request:
-    types: ['opened', 'synchronized']
+    types: ['opened', 'synchronize']
 
 jobs:
   test-regenerate-the-track1-sdks:

--- a/tools/autowrapper/main.go
+++ b/tools/autowrapper/main.go
@@ -66,6 +66,7 @@ func runAutoRestForService(serviceName, apiVersion, tag, readmeFilePath string, 
 		"--version=2.0.4421", // the version of autorest itself
 		"--go.license-header=MICROSOFT_MIT_NO_VERSION",
 		"--enum-prefix",
+		fmt.Sprintf("--namespace=%s", strings.ToLower(serviceName)),
 		typeArg,
 		fmt.Sprintf("--output-folder=%s", outputDirectory),
 		readmeFilePath,


### PR DESCRIPTION
Fixes the generation of `compute` - this also fixes the GHA for release (to release only when `./sdk` has been changed) and adds a GHA for validating the config is valid when a PR is opened