### PR TITLE
Config: Add botservice 2021-05-01-preview

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -30,3 +30,8 @@ resource_manager "synapse" "2021-06-01" {
   readme_file_path = "../../swagger/specification/synapse/resource-manager/readme.md"
 }
 
+
+resource_manager "botservice" "2021-05-01-preview" {
+  swagger_tag = "package-2021-05-01-preview"
+  readme_file_path = "../../swagger/specification/botservice/resource-manager/readme.md"
+}


### PR DESCRIPTION
The reason to add this is because the provider is currently using the same version for track1, but the track1 SDK is generated from a broken swagger version, which technically need to be regenerated, but they rejected to regenerate for track1 for such case. See https://github.com/Azure/azure-sdk-for-go/issues/19944.