### PR TITLE
Config: Add apimanagement 2021-08-01

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -50,3 +50,7 @@ resource_manager "botservice" "2021-05-01-preview" {
   readme_file_path = "../../swagger/specification/botservice/resource-manager/readme.md"
 }
 
+resource_manager "apimanagement" "2021-08-01" {
+  swagger_tag = "package-2021-08"
+  readme_file_path = "../../swagger/specification/apimanagement/resource-manager/readme.md"
+}


### PR DESCRIPTION
Property `metrics`  in  `diagnostic` was added after the release of the latest Azure Track1 SDK. 
Swagger update: https://github.com/Azure/azure-rest-api-specs/commit/a04115806a81d06f88764adee73193ff809188f3