### PR TITLE
tooling: using a version number/useragent from Kermit

### DIFF
--- a/scripts/determine-and-publish-git-tag.sh
+++ b/scripts/determine-and-publish-git-tag.sh
@@ -20,6 +20,15 @@ function determineGitTag {
   date '+v0.%Y%m%d.1%H%M%S'
 }
 
+function updateVersionNumber {
+  local version=$1
+  echo "package version
+
+const Number = \"${version}\"" > ./version/version.go
+
+  go fmt ./version/version.go
+}
+
 function publish {
   local version=$1
 
@@ -33,6 +42,7 @@ function publish {
 function main {
   local gitTag
   gitTag=$(determineGitTag)
+  updateVersionNumber "$gitTag"
   publish "$gitTag"
 }
 

--- a/scripts/determine-and-publish-git-tag.sh
+++ b/scripts/determine-and-publish-git-tag.sh
@@ -22,11 +22,16 @@ function determineGitTag {
 
 function updateVersionNumber {
   local version=$1
+
+  echo "Updating the User Agent Version to ${version}.."
   echo "package version
 
 const Number = \"${version}\"" > ./version/version.go
-
   go fmt ./version/version.go
+
+  echo "Committing the User Agent Version update to ${version}.."
+  git add ./version/version.go
+  git commit -m "version: updating the user agent version to ${version}"
 }
 
 function publish {
@@ -34,6 +39,9 @@ function publish {
 
   echo "Tagging as '$version'.."
   git tag "$version"
+
+  echo "Pushing Commit.."
+  git push
 
   echo "Pushing Tags.."
   git push --tags

--- a/scripts/update-user-agent.sh
+++ b/scripts/update-user-agent.sh
@@ -3,4 +3,10 @@
 # Since this SDK is no longer present within `Azure/azure-sdk-for-go`, using the user agent/version number from that
 # is misleading - it also means we unintentionally import the Azure SDK for Go.
 # Instead let's update the user agent to use a local version with the version number at release time
-find ../../sdk -type f -print0 | xargs -0 sed -i '' -e "s/Azure\/azure-sdk-for-go\/version/tombuildsstuff\/kermit\/version/" -e "s/Azure-SDK-For-Go\//tombuildsstuff\/kermit\//"
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  find ../../sdk -type f -print0 | xargs -0 sed -i '' -e "s/Azure\/azure-sdk-for-go\/version/tombuildsstuff\/kermit\/version/" -e "s/Azure-SDK-For-Go\//tombuildsstuff\/kermit\//"
+else
+  find ../../sdk -type f -print0 | xargs -0 sed -i -e "s/Azure\/azure-sdk-for-go\/version/tombuildsstuff\/kermit\/version/" -e "s/Azure-SDK-For-Go\//tombuildsstuff\/kermit\//"
+fi
+

--- a/scripts/update-user-agent.sh
+++ b/scripts/update-user-agent.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Since this SDK is no longer present within `Azure/azure-sdk-for-go`, using the user agent/version number from that
+# is misleading - it also means we unintentionally import the Azure SDK for Go.
+# Instead let's update the user agent to use a local version with the version number at release time
+find ../../sdk -type f -print0 | xargs -0 sed -i '' -e "s/Azure\/azure-sdk-for-go\/version/tombuildsstuff\/kermit\/version/" -e "s/Azure-SDK-For-Go\//tombuildsstuff\/kermit\//"

--- a/tools/autowrapper/GNUmakefile
+++ b/tools/autowrapper/GNUmakefile
@@ -12,6 +12,8 @@ fmt-generated:
 
 run: build
 	./autowrapper
+	# update the user agent string
+	sed -i '' -e "s/github.com\/Azure\/azure-sdk-for-go\/version/github.com\/tombuildsstuff\/kermit\/version/" -e "s/Azure-SDK-For-Go\//tombuildsstuff\/kermit\//" ../../sdk/**/*.go
 
 tools:
 	@echo "==> installing required tooling..."

--- a/tools/autowrapper/GNUmakefile
+++ b/tools/autowrapper/GNUmakefile
@@ -11,9 +11,10 @@ fmt-generated:
 	goimports -w ../../sdk
 
 run: build
+	@echo "==> generating SDKs..."
 	./autowrapper
-	# update the user agent string
-	sed -i '' -e "s/github.com\/Azure\/azure-sdk-for-go\/version/github.com\/tombuildsstuff\/kermit\/version/" -e "s/Azure-SDK-For-Go\//tombuildsstuff\/kermit\//" ../../sdk/**/*.go
+	@echo "==> updating the user agent..."
+	../../scripts/update-user-agent.sh
 
 tools:
 	@echo "==> installing required tooling..."

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,3 @@
+package version
+
+const Number = "TODO"


### PR DESCRIPTION
This works around an issue where this SDK depends on `Azure/azure-sdk-for-go`, when it doesn't.