### PR TITLE
batch: generating the data plane sdks

### DIFF
--- a/config/data-plane.hcl
+++ b/config/data-plane.hcl
@@ -1,5 +1,13 @@
 ## NOTE: these are relative paths from `./tools/autowrapper`
 
+data_plane "batch" "2020-03.11.0" {
+  swagger_tag      = "package-2020-03.11.0"
+  readme_file_path = "../../swagger/specification/batch/data-plane/readme.md"
+}
+data_plane "batch" "2022-01.15.0" {
+  swagger_tag      = "package-2022-01.15.0"
+  readme_file_path = "../../swagger/specification/batch/data-plane/readme.md"
+}
 data_plane "keyvault" "7.4" {
   swagger_tag      = "package-7.4"
   readme_file_path = "../../config/key-vault/readme.md"


### PR DESCRIPTION
This'll allow switching the Batch Data Plane SDK [currently used here](https://github.com/hashicorp/terraform-provider-azurerm/tree/177a92424b1a29b2f3094d31b32901881070dd8a/vendor/github.com/Azure/azure-sdk-for-go/services/batch/2020-03-01.11.0/batch) over to this repository