### PR TITLE
data-plane: generating the other `synapse` data plane sdks

### DIFF
--- a/config/data-plane.hcl
+++ b/config/data-plane.hcl
@@ -4,6 +4,14 @@ data_plane "keyvault" "7.4" {
   swagger_tag      = "package-7.4"
   readme_file_path = "../../config/key-vault/readme.md"
 }
+data_plane "synapse" "2019-06-01-preview" {
+  swagger_tag      = "package-vnet-2019-06-01-preview"
+  readme_file_path = "../../swagger/specification/synapse/data-plane/readme.md"
+}
+data_plane "synapse" "2020-08-01-preview" {
+  swagger_tag      = "package-access-control-2020-08-01-preview"
+  readme_file_path = "../../swagger/specification/synapse/data-plane/readme.md"
+}
 data_plane "synapse" "2021-06-01-preview" {
   swagger_tag      = "package-artifacts-2021-06-01-preview"
   readme_file_path = "../../swagger/specification/synapse/data-plane/readme.md"


### PR DESCRIPTION
Used here:

* https://github.com/hashicorp/terraform-provider-azurerm/tree/177a92424b1a29b2f3094d31b32901881070dd8a/vendor/github.com/Azure/azure-sdk-for-go/services/preview/synapse/2019-06-01-preview/managedvirtualnetwork
* https://github.com/hashicorp/terraform-provider-azurerm/tree/177a92424b1a29b2f3094d31b32901881070dd8a/vendor/github.com/Azure/azure-sdk-for-go/services/preview/synapse/2020-08-01-preview/accesscontrol