### PR TITLE
config: adding `appconfiguration` data plane `v1.0`

### DIFF
--- a/config/data-plane.hcl
+++ b/config/data-plane.hcl
@@ -1,5 +1,9 @@
 ## NOTE: these are relative paths from `./tools/autowrapper`
 
+data_plane "appconfiguration" "1.0" {
+  swagger_tag      = "package-1-0"
+  readme_file_path = "../../swagger/specification/appconfiguration/data-plane/readme.md"
+}
 data_plane "batch" "2020-03.11.0" {
   swagger_tag      = "package-2020-03.11.0"
   readme_file_path = "../../swagger/specification/batch/data-plane/readme.md"


### PR DESCRIPTION
This allows us to split this SDK out from `hashicorp/terraform-provider-azurerm` since this should be imported from here rather than embedded