### PR TITLE
add `compute` `2023-03-01`

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -30,6 +30,11 @@ resource_manager "compute" "2022-08-01" {
   readme_file_path = "../../swagger/specification/compute/resource-manager/readme.md"
 }
 
+resource_manager "compute" "2023-03-01" {
+  swagger_tag = "package-2023-03-01"
+  readme_file_path = "../../swagger/specification/compute/resource-manager/readme.md"
+}
+
 resource_manager "iothub" "2022-04-30-preview" {
   swagger_tag = "package-preview-2022-04-30"
   readme_file_path = "../../swagger/specification/iothub/resource-manager/readme.md"


### PR DESCRIPTION
to unblock https://github.com/hashicorp/terraform-provider-azurerm/issues/21690
spec link: https://github.com/Azure/azure-rest-api-specs/tree/main/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2023-03-01