### PR TITLE
add network @ 2023-06-01

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -55,6 +55,11 @@ resource_manager "network" "2022-11-01" {
   readme_file_path = "../../swagger/specification/network/resource-manager/readme.md"
 }
 
+resource_manager "network" "2023-06-01" {
+  swagger_tag = "package-2023-06"
+  readme_file_path = "../../swagger/specification/network/resource-manager/readme.md"
+}
+
 resource_manager "securityinsights" "2022-10-01-preview" {
   swagger_tag = "package-preview-2022-10"
   readme_file_path = "../../swagger/specification/securityinsights/resource-manager/readme.md"


### PR DESCRIPTION
The upgrade is due to support for [syncMode  ](https://github.com/Azure/azure-rest-api-specs/blob/42e2c0bcd77b0de6c523404668fa63511484d485/specification/network/resource-manager/Microsoft.Network/stable/2023-06-01/loadBalancer.json#L1894) of resource `azurerm_lb_backend_address_pool`