### PR TITLE
changing the swagger update to be weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
 - package-ecosystem: gitsubmodule
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
     time: "07:00"
     timezone: "UTC"
   open-pull-requests-limit: 2


### PR DESCRIPTION
We don't need this as often in this repository, monthly would be too slow - weekly is probably fine.