### PR TITLE
generate dataplane apis for Azure Search

### DIFF
--- a/config/data-plane.hcl
+++ b/config/data-plane.hcl
@@ -44,3 +44,7 @@ data_plane "synapse" "2021-06-01-preview" {
   swagger_tag      = "package-artifacts-2021-06-01-preview"
   readme_file_path = "../../swagger/specification/synapse/data-plane/readme.md"
 }
+data_plane "search" "2023-11-01" {
+  swagger_tag      = "package-2023-11-01"
+  readme_file_path = "../../swagger/specification/search/data-plane/Azure.Search/readme.md"
+}


### PR DESCRIPTION
As far as i understood the dataplane APIs are not (yet) part of https://github.com/hashicorp/go-azure-sdk .

I want to create datasources, indices and indexer for the Azure Search Service via terraform. See this old issue https://github.com/hashicorp/terraform-provider-azurerm/issues/11699

I tried to use the `Azure/go-azure-sdk` directly but it does only contain the arm endpoints as well (https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/resourcemanager/search/armsearch ).

Creating the above mentioned resources is done using the dataplane APIs.

See:
- https://learn.microsoft.com/en-us/rest/api/searchservice/data-sources/create-or-update?view=rest-searchservice-2023-11-01&tabs=HTTP
- https://learn.microsoft.com/en-us/rest/api/searchservice/indexes/create-or-update?view=rest-searchservice-2023-11-01&tabs=HTTP

I tried to run the generation locally, but nothing changed inside the `./sdk` folder. There was no error visible and exit code was 0.

Maybe I misconfigured something. Any ideas?

