### PR TITLE
add `compute` `2024-03-01`

### DIFF
--- a/config/resource-manager.hcl
+++ b/config/resource-manager.hcl
@@ -35,6 +35,11 @@ resource_manager "compute" "2023-03-01" {
   readme_file_path = "../../swagger/specification/compute/resource-manager/readme.md"
 }
 
+resource_manager "compute" "2024-03-01" {
+  swagger_tag = "package-2024-03-01"
+  readme_file_path = "../../swagger/specification/compute/resource-manager/readme.md"
+}
+
 resource_manager "datafactory" "2018-06-01" {
   swagger_tag = "package-2018-06"
   readme_file_path = "../../swagger/specification/datafactory/resource-manager/readme.md"


### PR DESCRIPTION
To support Implicit Disk Creation from Snapshot feature.
https://github.com/Azure/azure-rest-api-specs/blob/09c37754dac91874ff689ed1e60effb4268c8669/specification/compute/resource-manager/Microsoft.Compute/ComputeRP/stable/2024-03-01/computeRPCommon.json#L860